### PR TITLE
Allow `code` to be linkable

### DIFF
--- a/base.css
+++ b/base.css
@@ -20,7 +20,7 @@ body {
 }
 
 .vscode-body code {
-    color: initial;
+    color: inherit;
 }
 
 .vscode-body pre code {


### PR DESCRIPTION
`code` tags in `a`s now appear as links (like on GitHub).

### On GitHub

<img width="276" alt="github-example" src="https://user-images.githubusercontent.com/6137112/31570230-b18aff94-b04f-11e7-8a45-cc12328f6c2a.png">

### Markdown preview

#### Before

<img width="277" alt="vscode-before" src="https://user-images.githubusercontent.com/6137112/31570233-b60bb2a2-b04f-11e7-92eb-8659cc0e36bd.png">

#### After

<img width="282" alt="vscode-after" src="https://user-images.githubusercontent.com/6137112/31570235-b93be596-b04f-11e7-9d73-f3573422ce82.png">
