### PR TITLE
Font size configurable via `markdown.preview.fontSize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Changes VS Code's built-in markdown preview to match Github's styling
 
 > **❗️ Important**: This extension only styles the markdown preview. Use [this extension pack](https://marketplace.visualstudio.com/items?itemName=bierner.github-markdown-preview) to add support for other github markdown features like `:emoji:` and `- [ ] tasklists`.
 
-# Features 
+# Features
+
 - Preview what your markdown will look like rendered on Github 
 - Extends VS Code's built-in markdown preview
 - Customize styling using your own [`markdown.styles`](https://code.visualstudio.com/Docs/languages/markdown#_using-your-own-css) css
+- Set font size via `markdown.preview.fontSize`
 
 # Usage
 

--- a/build/update-github-markdown-css.js
+++ b/build/update-github-markdown-css.js
@@ -9,11 +9,23 @@ const fullPath = path.join(__dirname, '..', inputPath);
 
 function updateGithubMarkdownCss(input) {
     return `/* Generated from '${inputPath}' */\n`+ input.replace(/\.markdown-body/g, '.vscode-body');
-} 
+}
+
+/**
+ * Comments out `font-size: 16px;` so that the `markdown.preview.fontSize` configuration applies.
+ */
+function enablePreviewFontSize(input) {
+    return input.replace(
+        // https://regex101.com/r/LL2lma/2
+        /(\.vscode-body {[^}]+)(font-size: \d+px;)([^}]+})/s,
+        '$1/* $2 */   /* let\'s inherit `markdown.preview.fontSize` */$3'
+    );
+}
 
 
 const input = fs.readFileSync(fullPath, 'utf8');
 
 fs.writeFileSync(
     path.join(__dirname, '..', 'github-markdown.css'),
-    updateGithubMarkdownCss(input));
+    enablePreviewFontSize(updateGithubMarkdownCss(input))
+);

--- a/github-markdown.css
+++ b/github-markdown.css
@@ -10,7 +10,7 @@
   line-height: 1.5;
   color: #24292e;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-size: 16px;
+  /* font-size: 16px; */   /* let's inherit `markdown.preview.fontSize` */
   line-height: 1.5;
   word-wrap: break-word;
 }


### PR DESCRIPTION
Resolves #30 

It works by commenting out this line:

https://github.com/mjbvz/vscode-github-markdown-preview-style/blob/2452ef03f2c4a840c06feff93b8b37938f70a5a1/github-markdown.css#L13

in which case the preview reacts to `markdown.preview.fontSize` nicely. For example, 10px:

<img width="1418" alt="Screenshot 2019-04-04 at 23 48 44" src="https://user-images.githubusercontent.com/101152/55590798-358f2400-5734-11e9-8873-a5f5dd3f041e.png">

Font size 24:

<img width="1418" alt="Screenshot 2019-04-04 at 23 49 49" src="https://user-images.githubusercontent.com/101152/55590843-59eb0080-5734-11e9-990e-76e777151802.png">

---

I looked through the rest of the CSS for other instances of setting explicit pixel font sizes but they always seem to be overridden by an `em` rule rule which is good. For example, on line **265**:

https://github.com/mjbvz/vscode-github-markdown-preview-style/blob/2452ef03f2c4a840c06feff93b8b37938f70a5a1/github-markdown.css#L264-L267

And then later on line **495**:

https://github.com/mjbvz/vscode-github-markdown-preview-style/blob/2452ef03f2c4a840c06feff93b8b37938f70a5a1/github-markdown.css#L493-L497

Fortunately, these two are in the right order so I think that just disabling `16px` in `.vscode-body` is enough.