### PR TITLE
Show editor line indicator regardless of theme

### DIFF
--- a/dist/base.css
+++ b/dist/base.css
@@ -66,3 +66,7 @@ body,
   margin-top: 16px;
   margin-bottom: 16px;
 }
+
+.vscode-dark.showEditorSelection .code-line:hover:before {
+    border-left: 3px solid var(--color-fg-default);
+}


### PR DESCRIPTION
### Summary

- Use github style variables to always color the editor bar in a color that works for the background

Resolves #79 