### PR TITLE
Remove borders on codeblocks

### DIFF
--- a/dist/base.css
+++ b/dist/base.css
@@ -38,6 +38,7 @@ body,
 
 .github-markdown-body pre {
     color: initial;
+    border: none;
 }
 
 .github-markdown-body code {


### PR DESCRIPTION
Part of #115 

The default styling of the markdown preview applies the `widgets.border` color to codeblocks in the markdown preview.

![2023-09-08_14-34](https://github.com/mjbvz/vscode-github-markdown-preview-style/assets/8007967/333e1b45-08e0-4ba0-8b28-53ba8ddd47ee)

This PR just removes that border to match the fact that GitHub does not add borders to these blocks

### Testing

- Add a color customization to your settings
    ```json
    "workbench.colorCustomizations": {
        "widget.border": "#000"
  }
    ```
- Create a markdown file with a codeblock containing anything
- Check that there is no border on this branch

