### PR TITLE
Bump `generate-github-markdown-css` version for missing vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/markdown-it": "^13.0.7",
-        "generate-github-markdown-css": "^6.2.0"
+        "generate-github-markdown-css": "^6.3.0"
       },
       "engines": {
         "vscode": "^1.41.0"
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/generate-github-markdown-css": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/generate-github-markdown-css/-/generate-github-markdown-css-6.2.0.tgz",
-      "integrity": "sha512-k4n96lkLFEwIqymU2h/uqRoPV8rCYL/4Odq3QDyXLC82Hh85K5MH8Hdqi2q8JM3ZVN2PL0efB7NEIHbM1rrYKA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/generate-github-markdown-css/-/generate-github-markdown-css-6.3.0.tgz",
+      "integrity": "sha512-TRHYN2n/1Iv5PHAS0CTQBuYCikOGCQHqXuXxt/kh5c6iLbeKMq09YqbuBPelnUcJxQcqbT2RYhUMF7DVkVauSw==",
       "dev": true,
       "dependencies": {
         "css": "^3.0.0",
@@ -498,9 +498,9 @@
       "dev": true
     },
     "generate-github-markdown-css": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/generate-github-markdown-css/-/generate-github-markdown-css-6.2.0.tgz",
-      "integrity": "sha512-k4n96lkLFEwIqymU2h/uqRoPV8rCYL/4Odq3QDyXLC82Hh85K5MH8Hdqi2q8JM3ZVN2PL0efB7NEIHbM1rrYKA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/generate-github-markdown-css/-/generate-github-markdown-css-6.3.0.tgz",
+      "integrity": "sha512-TRHYN2n/1Iv5PHAS0CTQBuYCikOGCQHqXuXxt/kh5c6iLbeKMq09YqbuBPelnUcJxQcqbT2RYhUMF7DVkVauSw==",
       "dev": true,
       "requires": {
         "css": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   },
   "devDependencies": {
     "@types/markdown-it": "^13.0.7",
-    "generate-github-markdown-css": "^6.2.0"
+    "generate-github-markdown-css": "^6.3.0"
   },
   "scripts": {
     "vscode:prepublish": "npm run build",


### PR DESCRIPTION
Quick PR to bump dependency version. Fixes #138 Fixes #137

Github has updated it's css with new variable name formats and added a few more that the previous version of `generate-github-markdown-css` was missing. This was important because the external support added for Github's Alert syntax in other extensions is broken without them. <sub>I still don't agree with that syntax (see [discussion](https://github.com/orgs/community/discussions/16925) but the extension shouldn't be broken</sub>

@mjbvz I wasn't sure if this would be a minor or patch version bump so I left that up to you.

### Testing

- Run `npm run build` to generate the new versions of the CSS files
- Run the extension with a test markdown file
- Ensure all themes still look good 

Edit: I don't have the alert extension installed but I just realized that [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) now adds support for it and it did have the wrong rendering so that's a way to verify.