### PR TITLE
Only apply overscroll padding to top level `body`

### DIFF
--- a/dist/base.css
+++ b/dist/base.css
@@ -28,7 +28,11 @@ body,
 .vscode-body.scrollBeyondLastLine {
     margin-bottom: 0;
 }
-.vscode-body.scrollBeyondLastLine .github-markdown-body {
+/*
+ * Other extensions may reuse the markdown render function for embedding additional documents
+ * creating multiple .github-markdown-body elements so this should only apply to the top one
+ */
+.vscode-body.scrollBeyondLastLine > .markdown-body > .github-markdown-body {
     padding-bottom: calc(100vh + 10px) !important;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mjbvz/vscode-github-markdown-preview-style/issues/145

Other extensions (Like [Foam](https://marketplace.visualstudio.com/items?itemName=foam.foam-vscode)) can embed other MD files inside the preview. Foam does this by calling the markdownit render function again which this extension augments to include the `.github-markdown-body` and `.github-markdown-content`elements. This causes duplicates that were not originally expected.

This PR changes the overscroll padding to only apply to the top level github markdown body to avoid affecting these "embedded" pages

### Testing

1. Install [Foam](https://marketplace.visualstudio.com/items?itemName=foam.foam-vscode)
2. Create 2 notes as indicated in #145 (or just any with an embed and content _after_ the embed)
3. Open the Markdown preview
4. Check that the embedded preview does not have a ton of whitespace after it and that the content after the embed is visible and not getting overlapped.